### PR TITLE
feat: add KubeStellar Console to Kubernetes section

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Indicators: ⭐ Widely adopted · 🟢 Active · 🔵 Cloud-native · 🟠 Comme
 - [OpenSearch Dashboards](https://github.com/opensearch-project/OpenSearch-Dashboards) - 🟢🔵 Open-source fork of Kibana for OpenSearch.
 - [Apache Superset](https://github.com/apache/superset) - 🟢 SQL-first analytics and dashboarding platform for ad-hoc data exploration.
 - [Perses](https://github.com/perses/perses) - 🟢🔵 CNCF sandbox dashboards-as-code project with native PromQL and TraceQL support.
+- [KubeStellar Console](https://github.com/kubestellar/console) - 🟢🔵 Multi-cluster Kubernetes dashboard with real-time observability, AI-powered operations, and CNCF project integrations across edge and cloud clusters.
 
 ### Profiling & Continuous Performance Analysis
 


### PR DESCRIPTION
[KubeStellar Console](https://github.com/kubestellar/console) is an open-source multi-cluster Kubernetes dashboard — CNCF Sandbox project with AI-powered operations, 20+ CNCF integrations (Argo, Kyverno, Istio, Prometheus), and real-time observability across edge and cloud.\n\n*Happy to adjust description or placement.*